### PR TITLE
Added links to github repos for assignments. (Issue #49)

### DIFF
--- a/content/assignments/techjobs-mvc/getting-started/_index.md
+++ b/content/assignments/techjobs-mvc/getting-started/_index.md
@@ -16,7 +16,7 @@ lastMod: 2023-09-23T09:59:59-05:00 # UPDATE ANY TIME CHANGES ARE MADE
 
 Set up a local copy of the project:
 
-1. In Canvas, **Graded Assignment #3: TechJobs (MVC Edition)** contains a GitHub repo link. Fork, clone, and then set up the project in IntelliJ. Refer back to the instructions from [Assignment 0]({{% relref "../../hello-world/#getting-started" %}}) for details. 
+1. The starter code for this project is in [this github repository](https://github.com/LaunchCodeEducation/techjobs-mvc-java-graded-17.git). Fork, clone, and then set up the project in IntelliJ. Refer back to the instructions from [Assignment 0]({{% relref "../../hello-world/#getting-started" %}}) for details. 
 1. Launch the application (via the Gradle pane, *Tasks > Application >
    bootRun*) to make sure it starts up. Then shut it down.
 1. Run the autograding tests. The tests for this assignment are set up the same way as for [Assignment 2]({{% relref "../../techjobs-oo/task7/#run-the-tests" %}}). There are four tasks for this assignment, but the first doesn't require any coding on your part. Therefore, there are 3 test files (for tasks 2-4). As with Assignment 2, we recommend that you only run the tests for the task you are currently working on.

--- a/content/assignments/techjobs-oo/_index.md
+++ b/content/assignments/techjobs-oo/_index.md
@@ -47,7 +47,7 @@ In this project, you’ll show that you can:
 You may need to enable actions within your github repository if you have not done so already. Please refer back to the instructions on how to do so in the [Running the Autogtrading Tests through Github Actions]({{% relref "../hello-world/#running-the-autograding-tests-through-github-actions" %}}) section of `Assignment 0` 
 {{% /notice %}}
 
-In Canvas, **Graded Assignment #2: Object-Oriented Edition** contains a GitHub starter code repo link. Fork the repository to your personal profile, copy the repo’s URL for cloning, and open up IntelliJ. and then set up the project in IntelliJ. Refer back to the setup instructions from [assignment 0]({{% relref "../hello-world/#getting-started" %}}) for more details. 
+The starter code for this project is in [this github repository](https://github.com/LaunchCodeEducation/techjobs-oo-java-graded-17.git). Fork the repository to your personal profile, copy the repo’s URL for cloning, and open up IntelliJ. and then set up the project in IntelliJ. Refer back to the setup instructions from [assignment 0]({{% relref "../hello-world/#getting-started" %}}) for more details. 
 
 ## Introduction
 Sally has gotten the ball rolling by adding a `Job` class, along with classes to represent the individual properties of a job: `Employer`, `Location`, `PositionType`, and `CoreCompetency`. She completed the Employer class, and she left you the task of filling in the others.

--- a/content/assignments/techjobs-persistent/starter-code-review/index.md
+++ b/content/assignments/techjobs-persistent/starter-code-review/index.md
@@ -17,7 +17,7 @@ lastMod: # UPDATE ANY TIME CHANGES ARE MADE
 
 Set up a local copy of the project:
 
-1. In Canvas, find **Graded Assignment #4: TechJobs (Persistent Edition)** and click on the starter code repo link. Fork the repository to your personal profile, copy the repo's URL for cloning, and open up IntelliJ. Refer back to the instructions from [assignment0]({{% relref "../../hello-world/_index.md#getting-started" %}}) for more details.
+1. The starter code for this project is in [this github repository](https://github.com/LaunchCodeEducation/techjobs-persistent-java-graded-17.git). Fork the repository to your personal profile, copy the repo's URL for cloning, and open up IntelliJ. Refer back to the instructions from [assignment0]({{% relref "../../hello-world/_index.md#getting-started" %}}) for more details.
 1. Launch the application (via the Gradle pane, *Tasks > Application > bootRun*) to make sure it starts up properly. Then shut it down.
 <!-- TODO: Link below will need to be updated once assignment 2 is in the book -->
 1. The tests for this assignment are set up the same way as for [Tech Jobs OO]({{% relref "../../techjobs-oo/_index.md" %}}).


### PR DESCRIPTION
Graded assignments 2-4 had the same previously logged issue as assignment 1 had:

The book sends them to canvas for the github link, and canvas sends them to the book for the github link.  I added github links here to the book as I did for the first assignment (this time with the correct jdk17 projects)